### PR TITLE
escaping / encoding issue

### DIFF
--- a/github.js
+++ b/github.js
@@ -28,7 +28,7 @@
         url: API_URL + path,
         data: JSON.stringify(data),
         dataType: 'json',
-        contentType: 'application/x-www-form-urlencoded',
+        contentType: 'application/json',
         success: function(res) { cb(null, res); },
         error: function(err) { cb(err); },
         headers : headers()
@@ -40,7 +40,7 @@
         type: method,
         url: API_URL + path,
         data: JSON.stringify(data),
-        contentType: 'application/x-www-form-urlencoded',
+        contentType: 'application/json',
         success: function(res) { cb(null, res); },
         error: function(err) { cb(err); },
         headers : headers()


### PR DESCRIPTION
When doing a request the `contentType` was set `application/x-www-form-urlencoded`, because of this characters like '%' were messing things up.

I changed the `contentType` to `application/json`.

You can reproduce it by 'creating' a blob with the following content: 'hello world 100%'.
