### PR TITLE
Avoiding callback errors

### DIFF
--- a/github.js
+++ b/github.js
@@ -20,7 +20,7 @@
       xhr.onreadystatechange = function () {
         if (this.readyState == 4) {
           if (this.status >= 200 && this.status < 300 || this.status === 304) {
-            cb(null, raw ? this.responseText : JSON.parse(this.responseText));
+            cb(null, raw ? this.responseText : this.responseText ? JSON.parse(this.responseText) : true);
           } else {
             cb(this.status);
           }


### PR DESCRIPTION
If on success there is no XHR responseText, output true instead to avoid errors being created in callback.

For instance, delete a gist, there is no callback text to pass back and currently this causes an error. With this change it now passes back true instead, which is a more positive response that actually everything went well.
