### PR TITLE
Creates repo.branch function , closes #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Fork repository. This operation runs asynchronously. You may want to poll for `r
 repo.fork(function(err) {});
 ```
 
+Branch repository.
+
+```js
+repo.branch(oldBranchName,newBranchName, function(err) {});
+```
+
 Create Pull Request.
 
 ```js

--- a/github.js
+++ b/github.js
@@ -336,6 +336,26 @@
         _request("POST", repoPath + "/forks", null, cb);
       };
 
+      // Branch repository
+      // --------
+
+      this.branch = function(oldBranch,newBranch,cb) {
+        if(arguments.length === 2) {
+          if(typeof arguments[1] === "function") {
+            cb = newBranch;
+            newBranch = oldBranch;
+            oldBranch = "master";
+          }
+        }
+        this.getRef("heads/" + oldBranch, function(err,ref) {
+          if(err && cb) return cb(err);
+          that.createRef({
+            ref: "refs/heads/" + newBranch,
+            sha: ref
+          },cb);
+        });
+      }
+
       // Create pull request
       // --------
 


### PR DESCRIPTION
``` js
repo.branch(oldBranchName,newBranchName,cb)
```

or

``` js
repo.branch(newBranchName,cb) //default branches from "master"
```

Under the hood, it's just creating a new ref under refs/heads of the ref for the old branch.
