### PR TITLE
List commits on a repo

### DIFF
--- a/github.js
+++ b/github.js
@@ -420,11 +420,42 @@
         });
       };
 
-      // List commits on a repository
+      // List commits on a repository. Takes an object of optional paramaters:
+      // sha: SHA or branch to start listing commits from
+      // path: Only commits containing this file path will be returned
+      // author: GitHub login, name, or email by which to filter by commit author
+      // since: ISO 8601 date - only commits after this date will be returned
+      // until: ISO 8601 date - only commits before this date will be returned
       // -------
 
-      this.getCommits = function(cb) {
-          _request("GET", repoPath + "/commits", null, cb);
+      this.getCommits = function(cb, options) {
+          options = options || {};
+          var url = repoPath + "/commits";
+          var params = [];
+          if (options.sha) {
+              params.push("sha=" + encodeURIComponent(options.sha));
+          }
+          if (options.path) {
+              params.push("path=" + encodeURIComponent(options.path));
+          }
+          if (options.since) {
+              var since = options.since;
+              if (since.constructor === Date) {
+                  since = since.toISOString();
+              }
+              params.push("since=" + encodeURIComponent(since));
+          }
+          if (options.until) {
+              var until = options.until;
+              if (until.constructor === Date) {
+                  until = until.toISOString();
+              }
+              params.push("until=" + encodeURIComponent(until));
+          }
+          if (params.length > 0) {
+              url += "?" + params.join("&");
+          }
+          _request("GET", url, null, cb);
       };
     };
 


### PR DESCRIPTION
I'm working on an application that requires the most recent commits that a user has made to a repository.

This adds the call to the GitHub API to fetch the [list of commits](http://developer.github.com/v3/repos/commits/#list-commits-on-a-repository) (paginated as per API).
