### PR TITLE
adding _parseLinkHeader() to fetch complete unpaginated response

### DIFF
--- a/github.js
+++ b/github.js
@@ -36,7 +36,7 @@
       xhr.onreadystatechange = function () {
         if (this.readyState == 4) {
           if (this.status >= 200 && this.status < 300 || this.status === 304) {
-            cb(null, raw ? this.responseText : this.responseText ? JSON.parse(this.responseText) : true);
+            cb(null, raw ? this.responseText : this.responseText ? JSON.parse(this.responseText) : true, this);
           } else {
             cb({request: this, error: this.status});
           }
@@ -56,8 +56,50 @@
       data ? xhr.send(JSON.stringify(data)) : xhr.send();
     }
 
+    function _parseLinkHeader(err, response, xhr, cb) {
+      var link = xhr.getResponseHeader('link');
 
+      if (!err && link) {
+        var parts = link.split(',');
+        var length = parts.length;
 
+        var links = {};
+
+        var section;
+        var url;
+        var name;
+
+        for (var i = 0; i < length; i++) {
+          section = parts[i].split(';');
+
+          if (section.length !== 2) {
+            throw new Error("section could not be split on ';'");
+          }
+
+          url = section[0].replace(/<(.*)>/, '$1').trim();
+          name = section[1].replace(/rel="(.*)"/, '$1').trim();
+
+          links[name] = url;
+        }
+
+        if (links['next']) {
+          _request('GET', links['next'].split(API_URL)[1], null, function(err, res, xhr) {
+            if (typeof response.concat === 'function') {
+              response = response.concat(res);
+            } else if (typeof response === 'string') {
+              response += res;
+            }
+
+            _parseLinkHeader(err, response, xhr, cb);
+          });
+        } else {
+          cb(err, response);
+        }
+      } else {
+        cb(err, response);
+      }
+    }
+      
     // User API
     // =======
 
@@ -119,8 +161,8 @@
       // -------
 
       this.orgRepos = function(orgname, cb) {
-        _request("GET", "/orgs/"+orgname+"/repos?type=all&per_page=1000&sort=updated&direction=desc", null, function(err, res) {
-          cb(err, res);
+        _request("GET", "/orgs/"+orgname+"/repos?type=all&per_page=1000&sort=updated&direction=desc", null, function(err, res, xhr) {
+          _parseLinkHeader(err, res, xhr, cb);
         });
       };
 


### PR DESCRIPTION
Github.orgRepos() now returns ALL organization repositories instead of only the first page of results ([limited to 100](http://developer.github.com/v3/#pagination))
