### PR TITLE
Add user notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,13 @@ user.orgs(function(err, orgs) {});
 List authenticated user's gists.
 
 ```js
-user.gists(username, function(err, gists) {});
+user.gists(function(err, gists) {});
+```
+
+List unread notifications for the authenticated user.
+
+```js
+user.notifications(function(err, notifications) {});
 ```
 
 Show user information for a particular username. Also works for organizations.

--- a/github.js
+++ b/github.js
@@ -86,6 +86,15 @@
         });
       };
 
+      // List authenticated user's unread notifications
+      // -------
+
+      this.notifications = function(cb) {
+        _request("GET", "/notifications", null, function(err, res) {
+          cb(err,res);
+        });
+      };
+
       // Show user information
       // -------
 


### PR DESCRIPTION
This commit fixes #43 by adding support for listing the current user's notifications. 

```
user.notifications(function(err, notifications){});
```

It will only list unread notifications. If anyone is interested, I will add support for listing all and filtering. I also updated the README to reflect the changes. 
