### PR TITLE
Renamed gist delete method

### DIFF
--- a/github.js
+++ b/github.js
@@ -463,10 +463,10 @@
         _request("POST","/gists", options, cb);
       };
 
-      // Delete the gist
+      // Remove the gist
       // --------
 
-      this.delete = function(cb) {
+      this.remove = function(cb) {
         _request("DELETE", gistPath, null, function(err,res) {
           cb(err,res);
         });


### PR DESCRIPTION
Renamed gist `delete` method to `remove` because it's a reserved word
(that will cause a parsing error in air applications and older
browsers) and to be consistent (the method to delete a file in a repo
is also named as `remove`.

Parsing error from air application:
![bildschirmfoto 2013-06-11 um 13 02 39](https://f.cloud.github.com/assets/2519814/636527/7816785c-d286-11e2-9c42-c7a62360a30c.png)
