### PR TITLE
Keep header comment on minify

### DIFF
--- a/github.js
+++ b/github.js
@@ -1,8 +1,14 @@
-// Github.js 0.9.0
-// (c) 2013 Michael Aufreiter, Development Seed
-// Github.js is freely distributable under the MIT license.
-// For all details and documentation:
-// http://substance.io/michael/github
+/*!
+ * @overview  Github.js 0.9.0
+ *
+ * @copyright (c) 2013 Michael Aufreiter, Development Seed
+ *            Github.js is freely distributable.
+ *
+ * @license   Licensed under MIT license
+ *
+ *            For all details and documentation:
+ *            http://substance.io/michael/github
+ */
 
 (function() {
 


### PR DESCRIPTION
Some minifier keep header comment over its format.
1. YUI Compressor
   It keeps the header comments beggining with `/*!`
   - http://yui.github.io/yuicompressor/css.html#special-comments
2. Closure compiler
   It keeps the header comments containing `@license` or `@preserve`
   - https://developers.google.com/closure/compiler/docs/js-for-compiler#tag-license

I think header comment is very important because it includes its own license.
