### PR TITLE
Edit "auth" on reamde

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Create a Github instance.
 ```js
 var github = new Github({
   username: "YOU_USER",
-  password: "YOUR_PASSWORD"
+  password: "YOUR_PASSWORD",
+  auth: "basic"
 });
 ```
 
@@ -32,7 +33,8 @@ Or if you prefer OAuth, it looks like this:
 
 ```js
 var github = new Github({
-  token: "OAUTH_TOKEN"
+  token: "OAUTH_TOKEN",
+  auth: "oauth"
 });
 ```
 


### PR DESCRIPTION
I was working off the GitHub readme this weekend for a bit and finally realized that it is out of date a bit and that the NPM version is more current.

This pull request adds the missing "auth" parts of the access object that are on the NPM readme but not this one.
