### PR TITLE
Adding support for updating binary files

### DIFF
--- a/github.js
+++ b/github.js
@@ -357,7 +357,12 @@
             "content": content,
             "encoding": "utf-8"
           };
-        }
+        } else {
+          	content = {
+              "content": btoa(String.fromCharCode.apply(null, new Uint8Array(content))),
+              "encoding": "base64"
+            };
+          }
 
         _request("POST", repoPath + "/git/blobs", content, function(err, res) {
           if (err) return cb(err);


### PR DESCRIPTION
Updated to attempted to support JavaScript ArrayBuffers as an optional content when setting a blob.  This allows you to persist binary content you'd happen to load through JavaScript.
