### PR TITLE
Adding pagination to getCommits

### DIFF
--- a/github.js
+++ b/github.js
@@ -640,6 +640,12 @@
               }
               params.push("until=" + encodeURIComponent(until));
           }
+          if (options.page) {
+              params.push("page=" + options.page);
+          }
+          if (options.perpage) {
+              params.push("per_page=" + options.perpage);
+          }
           if (params.length > 0) {
               url += "?" + params.join("&");
           }


### PR DESCRIPTION
The Github API supports pagination, using the page and per_page parameters. I've included support for that from within the function getCommits
