### PR TITLE
fix(repository): Fix getContributors method URL. Add getContributorStats method.

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -384,6 +384,16 @@ class Repository extends Requestable {
     * @return {Promise} - the promise for the http request
     */
    getContributors(cb) {
+      return this._request('GET', `/repos/${this.__fullname}/contributors`, null, cb);
+   }
+
+   /**
+    * List the contributor stats to the repository
+    * @see https://developer.github.com/v3/repos/#list-contributors
+    * @param {Requestable.callback} cb - will receive the list of contributors
+    * @return {Promise} - the promise for the http request
+    */
+   getContributorStats(cb) {
       return this._request('GET', `/repos/${this.__fullname}/stats/contributors`, null, cb);
    }
 

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -181,6 +181,23 @@ describe('Repository', function() {
 
             const contributor = contributors[0];
 
+            expect(contributor).to.have.own('login');
+            expect(contributor).to.have.own('contributions');
+
+            done();
+         }));
+      });
+
+      it('should show repo contributor stats', function(done) {
+         remoteRepo.getContributorStats(assertSuccessful(done, function(err, contributors) {
+            if (!(contributors instanceof Array)) {
+               console.log(JSON.stringify(contributors, null, 2)); // eslint-disable-line
+            }
+            expect(contributors).to.be.an.array();
+            expect(contributors.length).to.be.above(1);
+
+            const contributor = contributors[0];
+
             expect(contributor).to.have.own('author');
             expect(contributor).to.have.own('total');
             expect(contributor).to.have.own('weeks');


### PR DESCRIPTION
Based on this https://developer.github.com/v3/repos/#list-contributors method to get contributors is /repos/:owner/:repo/contributors . It was using /repos/:owner/:repo/stats/contributors . I have renamed old method to getContributorStats. Also it fixes performance issue, /repos/:owner/:repo/contributors endpoint is much faster.
