### PR TITLE
Adds missing `getCombinedStatus` method to Repository.js

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -232,6 +232,17 @@ class Repository extends Requestable {
    }
 
    /**
+    * Get the combined commit Status for a specific sha, branch or tag
+    * @see https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+    * @param {string} sha - the sha, branch, or tag to get statuses for
+    * @param {Requestable.callback} cb - will receive the list of statuses
+    * @return {Promise} - the promise for the http request
+    */
+   getCombinedStatus(sha, cb) {
+      return this._request('GET', `/repos/${this.__fullname}/commits/${sha}/status`, null, cb);
+   }
+
+   /**
     * Get a description of a git tree
     * @see https://developer.github.com/v3/git/trees/#get-a-tree
     * @param {string} treeSHA - the SHA of the tree to fetch

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -239,6 +239,21 @@ describe('Repository', function() {
          }));
       });
 
+      it('should get the combined status for a SHA from a repo', function(done) {
+         remoteRepo.getCombinedStatus(v10SHA, assertSuccessful(done, function(err, combinedStatus) {
+            expect(combinedStatus).to.be.an.object();
+            expect(combinedStatus).to.have.property('state');
+            expect(combinedStatus.state).to.equal('success');
+
+            expect(combinedStatus).to.have.property('statuses');
+            expect(combinedStatus.statuses).to.be.an.array();
+            expect(combinedStatus.statuses.length).to.equal(1);
+            expect(combinedStatus.statuses[0].url).to.equal(statusUrl);
+
+            done();
+         }));
+      });
+
       it('should get a SHA from a repo', function(done) {
          remoteRepo.getSha('master', '.gitignore', assertSuccessful(done));
       });


### PR DESCRIPTION
As I was about to use this great library I noticed it was missing the exact method I was using it for.
See https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref

So thought I better add it for the next person 😸 

__Changes:__
- Adds `getCombinedStatus` to the Repository.js module
- Adds simple test case for `getCombinedStatus` method
- Also fixes the only the only lint error in Repository.js

Let me know if it needs any changes 👍 

__Edit:__
Added test seems to be passing see:
https://travis-ci.org/michael/github/jobs/175262817#L1148