### PR TITLE
feat: use the page option to fetch a single page

### DIFF
--- a/lib/Requestable.js
+++ b/lib/Requestable.js
@@ -256,7 +256,7 @@ class Requestable {
             results.push(...thisGroup);
 
             const nextUrl = getNextPage(response.headers.link);
-            if (nextUrl) {
+            if (nextUrl && typeof options.page !== 'number') {
                log(`getting next page: ${nextUrl}`);
                return this._requestAllPages(nextUrl, options, cb, results);
             }


### PR DESCRIPTION
See the discussion on: https://github.com/github-tools/github/issues/406

Previous to this, the behavior is that specifying a page in options causes an infinite loop of requests and there is no way for calls that are delegated to requestAllPages to be paginated by the api user.
