### PR TITLE
Add methods to fetch gist's commits and specific revision

### DIFF
--- a/lib/Gist.js
+++ b/lib/Gist.js
@@ -109,6 +109,27 @@ class Gist extends Requestable {
    }
 
    /**
+    * List the gist's commits
+    * @see https://developer.github.com/v3/gists/#list-gist-commits
+    * @param {Requestable.callback} [cb] - will receive the array of commits
+    * @return {Promise} - the Promise for the http request
+    */
+   listCommits(cb) {
+      return this._requestAllPages(`/gists/${this.__id}/commits`, null, cb);
+   }
+
+   /**
+    * Fetch one of the gist's revision.
+    * @see https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist
+    * @param {string} revision - the id of the revision
+    * @param {Requestable.callback} [cb] - will receive the revision
+    * @return {Promise} - the Promise for the http request
+    */
+   getRevision(revision, cb) {
+      return this._request('GET', `/gists/${this.__id}/${revision}`, null, cb);
+   }
+
+   /**
     * List the gist's comments
     * @see https://developer.github.com/v3/gists/comments/#list-comments-on-a-gist
     * @param {Requestable.callback} [cb] - will receive the array of comments

--- a/test/gist.spec.js
+++ b/test/gist.spec.js
@@ -10,6 +10,7 @@ describe('Gist', function() {
    let gistId;
    let github;
    let commentId;
+   let revisionId;
 
    before(function() {
       github = new Github({
@@ -51,6 +52,7 @@ describe('Gist', function() {
             expect(gist).to.have.own('public', testGist.public);
             expect(gist).to.have.own('description', testGist.description);
             gistId = gist.id;
+            revisionId = gist.history[0].version;
 
             done();
          }));
@@ -98,6 +100,36 @@ describe('Gist', function() {
 
       it('should delete comment', function(done) {
          gist.deleteComment(commentId, assertSuccessful(done));
+      });
+
+      it('should update gist', function(done) {
+         const newGist = {
+            files: {
+               'README.md': {
+                  content: 'README updated',
+               },
+            },
+         };
+         gist.update(newGist, assertSuccessful(done, function(err, gist) {
+            expect(gist.history.length).to.be(2);
+            expect(gist.files['README.md']).to.have.own('content', newGist.files['README.md'].content);
+            done();
+         }));
+      });
+
+      it('should list commits', function(done) {
+         gist.listCommits(assertSuccessful(done, function(err, commits) {
+            expect(commits).to.be.an.array();
+            done();
+         }));
+      });
+
+      it('should get revision', function(done) {
+         gist.getRevision(revisionId, assertSuccessful(done, function(err, gist) {
+            expect(gist.history.length).to.be(1);
+            expect(gist.files['README.md']).to.have.own('content', testGist.files['README.md'].content);
+            done();
+         }));
       });
    });
 


### PR DESCRIPTION
First of all, thank you for this library!

I need to be able to get a specific revision of gist, so I added support for these two API methods:

- https://developer.github.com/v3/gists/#list-gist-commits
- https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist