### PR TITLE
Use _requestAllPages in listGists()

### DIFF
--- a/lib/User.js
+++ b/lib/User.js
@@ -88,7 +88,7 @@ class User extends Requestable {
     * @return {Promise} - the promise for the http request
     */
    listGists(cb) {
-      return this._request('GET', this.__getScopedUrl('gists'), null, cb);
+      return this._requestAllPages(this.__getScopedUrl('gists'), null, cb);
    }
 
    /**


### PR DESCRIPTION
Hi.

I've noticed today that User.listGists() returns smaller number of gists than what is my total number.
By looking at #408 and code I've tried modify code locally and use `_requestAllPages()` and it works as expected.

Feel free ask for more changes if necessary.