### PR TITLE
Docs fix for getProject

### DIFF
--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -117,7 +117,7 @@ class GitHub {
    /**
     * Create a new Project wrapper
     * @param {string} id - the id of the project
-    * @return {Markdown}
+    * @return {Project}
     */
    getProject(id) {
       return new Project(id, this.__auth, this.__apiBase);


### PR DESCRIPTION
Fixes typo shown in http://github-tools.github.io/github/docs/3.1.0/GitHub.html#getProject