### PR TITLE
feature(repository): add getCombinedStatus

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -232,6 +232,17 @@ class Repository extends Requestable {
    }
 
    /**
+    * Get the combined view of commit statuses for a particular sha, branch, or tag
+    * @see https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+    * @param {string} sha - the sha, branch, or tag to get the combined status for
+    * @param {Requestable.callback} cb - will receive the combined status
+    * @returns {Promise}
+    */
+   getCombinedStatus(sha, cb) {
+      return this._request('GET', `/repos/${this.__fullname}/commits/${sha}/status`, null, cb);
+   }
+
+   /**
     * Get a description of a git tree
     * @see https://developer.github.com/v3/git/trees/#get-a-tree
     * @param {string} treeSHA - the SHA of the tree to fetch

--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -236,7 +236,7 @@ class Repository extends Requestable {
     * @see https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
     * @param {string} sha - the sha, branch, or tag to get the combined status for
     * @param {Requestable.callback} cb - will receive the combined status
-    * @returns {Promise}
+    * @returns {Promise} - the promise for the http request
     */
    getCombinedStatus(sha, cb) {
       return this._request('GET', `/repos/${this.__fullname}/commits/${sha}/status`, null, cb);

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -239,6 +239,17 @@ describe('Repository', function() {
          }));
       });
 
+      it('should get combined view of commit statuses for a SHA from a repo', function(done) {
+         remoteRepo.getCombinedStatus(v10SHA, assertSuccessful(done, function(err, combinedStatusesView) {
+            expect(combinedStatusesView.sha).to.equal(v10SHA);
+            expect(combinedStatusesView.state).to.equal('success');
+            expect(combinedStatusesView.statuses[0].context).to.equal('continuous-integration/travis-ci/push');
+            expect(combinedStatusesView.total_count).to.equal(1);
+
+            done();
+         }));
+      });
+
       it('should get a SHA from a repo', function(done) {
          remoteRepo.getSha('master', '.gitignore', assertSuccessful(done));
       });


### PR DESCRIPTION
I added the `getCombinedStatus` method in `Repository.js` and an associated unit test to implement the GitHub get combined status API endpoint (https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref).

**NOTE:** The one unit test which is failing is not actually a problem with the unit tests themselves, but rather is being caused by the test harnesses inability to properly authenticate to GitHub.

closes #426 

@clayreimann 
@mtscout6 
@AurelioDeRosa 
@alexcanessa 