### PR TITLE
Refactor getTeams method & unit test to fix test suite

### DIFF
--- a/lib/Organization.js
+++ b/lib/Organization.js
@@ -75,7 +75,9 @@ class Organization extends Requestable {
     * @return {Promise} - the promise for the http request
     */
    getTeams(cb) {
-      return this._requestAllPages(`/orgs/${this.__name}/teams`, undefined, cb);
+      let requestOptions = this._getOptionsWithDefaults();
+
+      return this._request('GET', `/orgs/${this.__name}/teams`, requestOptions, cb);
    }
 
    /**

--- a/test/organization.spec.js
+++ b/test/organization.spec.js
@@ -95,13 +95,13 @@ describe('Organization', function() {
          }));
       });
 
-      it('should list the teams in the organization', function() {
-         return organization.getTeams()
-           .then(({data}) => {
-              const hasTeam = data.some((member) => member.slug === testRepoName);
+      it('should list the teams in the organization', function(done) {
+         organization.getTeams(assertSuccessful(done, function(err, teams) {
+            const hasTeam = teams.some((member) => member.slug === testRepoName);
 
-              expect(hasTeam).to.be.true();
-           });
+            expect(hasTeam).to.be.true();
+            done();
+         }));
       });
 
       it('should create a project', function(done) {


### PR DESCRIPTION
I refactored the `getTeams` method in `Organization.js` to use the new `_request` method instead of the deprecated `_requestAllPages` method, and I refactored the associated unit test to use `assetSuccessful` and `done()`, instead of returning the output from a chained `.then` handler method.

After making these changes, two of the three unit tests which were failing are now passing. The one unit test which is still failing is not actually a problem with the unit tests themselves, but rather is being caused by the test harnesses inability to properly authenticate to GitHub.

@clayreimann 
@mtscout6 
@AurelioDeRosa 
@alexcanessa 