### PR TITLE
Working with two-factor authentication

### DIFF
--- a/lib/Requestable.js
+++ b/lib/Requestable.js
@@ -54,6 +54,7 @@ class Requestable {
          token: auth.token,
          username: auth.username,
          password: auth.password,
+         otp: auth.otp || null
       };
       this.__AcceptHeader = AcceptHeader || 'v3';
 
@@ -101,6 +102,10 @@ class Requestable {
 
       if (this.__authorizationHeader) {
          headers.Authorization = this.__authorizationHeader;
+      }
+      
+      if (this.__auth.otp) {
+         headers['X-GitHub-OTP'] = this.__auth.otp;
       }
 
       return headers;


### PR DESCRIPTION
As mentioned in github API:
```
In addition to the Basic Authentication credentials, you must send the user's authentication code (i.e., one-time password) in the X-GitHub-OTP header.
```
And we will be able to use it like this:

```
const github = new GitHub({
    username: 'ddimitrioglo',
    password: 'xxxxxxxxxxxx',
    otp: '888999' // <= One-Time-Password
});

let me = github.getUser();

me.listRepos((err, repos) => {
    console.log(repos);
});
```