### PR TITLE
Fixed: Cannot read property 'encode' of undefined during executing writeFile()

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -713,6 +713,7 @@ class Repository extends Requestable {
     * @return {Promise} - the promise for the http request
     */
    writeFile(branch, path, content, message, options, cb) {
+      options = options || {};
       if (typeof options === 'function') {
          cb = options;
          options = {};


### PR DESCRIPTION
I am trying to execute writeFile without optional `options`-parameter. 
But getting the error:

```sh
~project/node_modules/github-api/dist/components/Repository.js:912
         var shouldEncode = options.encode !== false;
                                   ^

TypeError: Cannot read property 'encode' of undefined
    at Repository.writeFile (~project/node_modules/github-api/dist/components/Repository.js:912:36)
    at Object.<anonymous> (~project/gist.js:13:6)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
```