### PR TITLE
Enable to pass an object to createBlob

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -245,7 +245,7 @@ class Repository extends Requestable {
    /**
     * Create a blob
     * @see https://developer.github.com/v3/git/blobs/#create-a-blob
-    * @param {(string|Buffer|Blob)} content - the content to add to the repository
+    * @param {(string|Buffer|Blob|Object)} content - the content to add to the repository
     * @param {Requestable.callback} cb - will receive the details of the created blob
     * @return {Promise} - the promise for the http request
     */
@@ -258,7 +258,7 @@ class Repository extends Requestable {
 
    /**
     * Get the object that represents the provided content
-    * @param {string|Buffer|Blob} content - the content to send to the server
+    * @param {string|Buffer|Blob|Object} content - the content to send to the server
     * @return {Object} the representation of `content` for the GitHub API
     */
    _getContentObject(content) {
@@ -283,9 +283,18 @@ class Repository extends Requestable {
             encoding: 'base64',
          };
 
+      } else if (typeof content === 'object') {
+        log('content is an object');
+
+        if (typeof content.content !== 'string') {
+          throw new Error('The object must contain content item of type string.')
+        }
+
+        return content;
+
       } else { // eslint-disable-line
          log(`Not sure what this content is: ${typeof content}, ${JSON.stringify(content)}`);
-         throw new Error('Unknown content passed to postBlob. Must be string or Buffer (node) or Blob (web)');
+         throw new Error('Unknown content passed to postBlob. Must be string or Buffer (node) or Blob (web) or Object');
       }
    }
 


### PR DESCRIPTION
createBlob automatically encodes string parameter
by Utf8 library. In some cases the string value
can be already encoded in Utf8 so the encoding
should be skipped.

This commit enables to pass object containing
the content and encoding items. This object is
directly sent to Github. Users have better control
about what is actually sending.

closes #463