### PR TITLE
Added prepare script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "gulp clean",
     "build": "gulp build",
+    "prepare": "gulp build",
     "test": "mocha --opts ./mocha.opts test/*.spec.js",
     "test-coverage": "NODE_ENV=test nyc mocha --opts ./mocha.opts test/*.spec.js",
     "test-verbose": "DEBUG=github* npm test",


### PR DESCRIPTION
Since npm@5.0.0 the prepare script is called
when the library is installed from github url.
Aim of the script is to build distribution
files.

See https://github.com/npm/npm/issues/3055