### PR TITLE
Add options to the listReleases function

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -793,11 +793,12 @@ class Repository extends Requestable {
    /**
     * Get information about all releases
     * @see https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
+    * @param {Object} options - pagination for the list
     * @param {Requestable.callback} cb - will receive the release information
     * @return {Promise} - the promise for the http request
     */
-   listReleases(cb) {
-      return this._request('GET', `/repos/${this.__fullname}/releases`, null, cb);
+   listReleases(options, cb = options) {
+      return this._request('GET', `/repos/${this.__fullname}/releases`, options !== 'function' && options, cb);
    }
 
    /**

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -628,6 +628,15 @@ describe('Repository', function() {
       });
 
       it('should read all releases', function(done) {
+         const paginationOptions = {
+            per_page: 30
+         };
+
+         remoteRepo.listReleases(paginationOptions, assertSuccessful(done, function(err, releases) {
+            expect(releases).to.be.an.array();
+            done();
+         }));
+
          remoteRepo.listReleases(assertSuccessful(done, function(err, releases) {
             expect(releases).to.be.an.array();
             done();


### PR DESCRIPTION
The request to get the list of releases should have the options object in order to pass pagination options.

@see https://developer.github.com/v3/#pagination