### PR TITLE
Implementing methods to retrieve list of followers and following users.

### DIFF
--- a/lib/User.js
+++ b/lib/User.js
@@ -82,6 +82,26 @@ class User extends Requestable {
    }
 
    /**
+    * List followers of a user
+    * @see https://developer.github.com/v3/users/followers/#list-followers-of-a-user
+    * @param {Requestable.callback} [cb] - will receive the list of followers
+    * @return {Promise} - the promise for the http request
+    */
+   listFollowers(cb) {
+      return this._request('GET', this.__getScopedUrl('followers'), null, cb);
+   }
+
+   /**
+    * List users followed by another user
+    * @see https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user
+    * @param {Requestable.callback} [cb] - will receive the list of who a user is following
+    * @return {Promise} - the promise for the http request
+    */
+   listFollowing(cb) {
+      return this._request('GET', this.__getScopedUrl('following'), null, cb);
+   }
+
+   /**
     * List the user's gists
     * @see https://developer.github.com/v3/gists/#list-a-users-gists
     * @param {Requestable.callback} [cb] - will receive the list of gists

--- a/test/user.spec.js
+++ b/test/user.spec.js
@@ -34,6 +34,14 @@ describe('User', function() {
       user.listOrgs(assertArray(done));
    });
 
+   it('should get user followers', function(done) {
+      user.listFollowers(assertArray(done));
+   });
+
+   it('should get user following list', function(done) {
+      user.listFollowing(assertArray(done));
+   });
+
    it('should get user gists', function(done) {
       user.listGists(assertArray(done));
    });


### PR DESCRIPTION
## What

Github v3 provides the endpoints `followers` and `following` associated to the user entity. 

[**List followers of a user**](https://developer.github.com/v3/users/followers/#list-followers-of-a-user)
```
GET /users/:username/followers
```

[**List users followed by another user**](https://developer.github.com/v3/users/followers/#check-if-one-user-follows-another)
```
GET /users/:username/following
```

This change extends the User object by adding the methods `listFollowers` and `listFollowing`, in addition I've added basic unit tests for them.