### PR TITLE
Add stream response type option

### DIFF
--- a/lib/Requestable.js
+++ b/lib/Requestable.js
@@ -176,7 +176,7 @@ class Requestable {
          headers: headers,
          params: queryParams,
          data: data,
-         responseType: raw ? 'text' : 'json',
+         responseType: (raw==='stream') ? 'stream' : (raw ? 'text' : 'json'),
       };
 
       log(`${config.method} to ${config.url}`);


### PR DESCRIPTION
Hi, there, 
There has a bug when I download binary file with github api, and I found responseType needs to be stream but not text, so can you review this and marge?