### PR TITLE
Fixed null ref test failure.

### DIFF
--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -169,7 +169,7 @@ describe('Repository', function() {
 
       it('should fail when null ref is passed', function(done) {
          remoteRepo.getSingleCommit(null, assertFailure(done, function(err) {
-            expect(err.response.status).to.be(404);
+            expect(err.response.status).to.be(422);
             done();
          }));
       });


### PR DESCRIPTION
Closes #543. It looks like GitHub switched to returning 422 when the commit hash is not specified. Check [here](https://api.github.com/repos/github-tools/github/commits/) for reference.