### PR TITLE
Add commit author

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -334,15 +334,25 @@ class Repository extends Requestable {
     * @param {string} parent - the SHA of the parent commit
     * @param {string} tree - the SHA of the tree for this commit
     * @param {string} message - the commit message
+    * @param {Object} [options] - commit options
+    * @param {Object} [options.author] - the author of the commit
+    * @param {Object} [options.commiter] - the committer
     * @param {Requestable.callback} cb - will receive the commit that is created
     * @return {Promise} - the promise for the http request
     */
-   commit(parent, tree, message, cb) {
+   commit(parent, tree, message, options, cb) {
+      if (typeof options === 'function') {
+         cb = options;
+         options = {};
+      }
+
       let data = {
          message,
          tree,
          parents: [parent],
       };
+
+      data = Object.assign({}, options, data);
 
       return this._request('POST', `/repos/${this.__fullname}/git/commits`, data, cb)
          .then((response) => {

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -616,6 +616,29 @@ describe('Repository', function() {
          });
       });
 
+      it('should allow commit to change author', function(done) {
+         let parentSHA = '';
+         let treeSHA = '';
+         remoteRepo.getRef('heads/master').then((ref) => {
+            parentSHA = ref.data.object.sha;
+            return remoteRepo.getCommit(parentSHA);
+         }).then((commit) => {
+            treeSHA = commit.data.tree.sha;
+            return remoteRepo.commit(parentSHA, treeSHA, 'Who made this commit?', {
+               author: {
+                  name: 'Jimothy Halpert',
+                  email: 'jim@dundermifflin.com',
+               },
+            });
+         }).then((commit) => {
+            expect(commit.data.author).to.have.own('name', 'Jimothy Halpert');
+            expect(commit.data.author).to.have.own('email', 'jim@dundermifflin.com');
+            done();
+         }).catch((err) => {
+            throw err;
+         });
+      });
+
       it('should create a release', function(done) {
          const releaseDef = {
             name: releaseName,

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -600,6 +600,22 @@ describe('Repository', function() {
          }));
       });
 
+      it('should succeed on proper commit', function(done) {
+         let parentSHA = '';
+         let treeSHA = '';
+         remoteRepo.getRef('heads/master').then((ref) => {
+            parentSHA = ref.data.object.sha;
+            return remoteRepo.getCommit(parentSHA);
+         }).then((commit) => {
+            treeSHA = commit.data.tree.sha;
+            return remoteRepo.commit(parentSHA, treeSHA, 'is this thing on?');
+         }).then((commit) => {
+            expect(commit.data.author).to.have.own('name', 'Mike de Boer');
+            expect(commit.data.author).to.have.own('email', 'mike@c9.io');
+            done();
+         });
+      });
+
       it('should create a release', function(done) {
          const releaseDef = {
             name: releaseName,


### PR DESCRIPTION
Closes #546. 

The commit function can now accept optional parameters for setting who the author or committer is. See [here](https://developer.github.com/v3/git/commits/#create-a-commit) for GitHub's API on it.