### PR TITLE
Fork to organization

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -505,6 +505,18 @@ class Repository extends Requestable {
    }
 
    /**
+    * Fork a repository to an organization
+    * @see https://developer.github.com/v3/repos/forks/#create-a-fork
+    * @param {String} org - organization where you'd like to create the fork.
+    * @param {Requestable.callback} cb - will receive the information about the newly created fork
+    * @return {Promise} - the promise for the http request
+    *
+    */
+   forkToOrg(org, cb) {
+      return this._request('POST', `/repos/${this.__fullname}/forks?organization=${org}`, null, cb);
+   }
+
+   /**
     * List a repository's forks
     * @see https://developer.github.com/v3/repos/forks/#list-forks
     * @param {Requestable.callback} cb - will receive the list of repositories forked from this one

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -112,6 +112,10 @@ describe('Repository', function() {
          remoteRepo.fork(assertSuccessful(done));
       });
 
+      it('should fork repo to org', function(done) {
+         remoteRepo.forkToOrg(testUser.ORGANIZATION, assertSuccessful(done));
+      });
+
       it('should list forks of repo', function(done) {
          remoteRepo.listForks(assertSuccessful(done, function(err, forks) {
             expect(forks).to.be.an.array();


### PR DESCRIPTION
Code from PR #503 

Thanks to @benmonro for the original PR.

Switched 'test-org' to 'github-api-tests' as requested. Forked repo that the test creates can be found [here](https://github.com/github-api-tests/github).