### PR TITLE
Repository 'listCommits' working when options omitted

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -187,8 +187,10 @@ class Repository extends Requestable {
     * @return {Promise} - the promise for the http request
     */
    listCommits(options, cb) {
-      options = options || {};
-
+      if (typeof options === 'function') {
+         cb = options;
+         options = {};
+      }
       options.since = this._dateToISO(options.since);
       options.until = this._dateToISO(options.until);
 

--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -187,6 +187,7 @@ class Repository extends Requestable {
     * @return {Promise} - the promise for the http request
     */
    listCommits(options, cb) {
+      options = options || {};
       if (typeof options === 'function') {
          cb = options;
          options = {};

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -121,7 +121,7 @@ describe('Repository', function() {
       });
 
       it('should list commits with no options', function(done) {
-         remoteRepo.listCommits(null, assertSuccessful(done, function(err, commits) {
+         remoteRepo.listCommits(assertSuccessful(done, function(err, commits) {
             expect(commits).to.be.an.array();
             expect(commits.length).to.be.above(0);
 

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -132,6 +132,18 @@ describe('Repository', function() {
          }));
       });
 
+      it('should list commits with null options', function(done) {
+         remoteRepo.listCommits(null, assertSuccessful(done, function(err, commits) {
+            expect(commits).to.be.an.array();
+            expect(commits.length).to.be.above(0);
+
+            expect(commits[0]).to.have.own('commit');
+            expect(commits[0]).to.have.own('author');
+
+            done();
+         }));
+      });
+
       it('should list commits with all options', function(done) {
          const since = new Date(2015, 0, 1);
          const until = new Date(2016, 0, 20);


### PR DESCRIPTION
Fixes #508.

This PR resolves the issue of having to explicitly specify the options parameter. I also changed the existing test to properly validate a 'listCommits' function call without options.