### PR TITLE
Bump version of Axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dist/*"
   ],
   "dependencies": {
-    "axios": "^0.15.2",
+    "axios": "^0.19.0",
     "debug": "^2.2.0",
     "js-base64": "^2.1.9",
     "utf8": "^2.1.1"


### PR DESCRIPTION
Right now i get a github warning because the old version of axios has some major security warnings.