### PR TITLE
Implement combined status

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -235,6 +235,17 @@ class Repository extends Requestable {
    }
 
    /**
+    * Get the combined view of commit statuses for a particular sha, branch, or tag
+    * @see https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+    * @param {string} sha - the sha, branch, or tag to get the combined status for
+    * @param {Requestable.callback} cb - will receive the combined status
+    * @returns {Promise} - the promise for the http request
+    */
+   getCombinedStatus(sha, cb) {
+      return this._request('GET', `/repos/${this.__fullname}/commits/${sha}/status`, null, cb);
+   }
+
+   /**
     * Get a description of a git tree
     * @see https://developer.github.com/v3/git/trees/#get-a-tree
     * @param {string} treeSHA - the SHA of the tree to fetch

--- a/test/issue.spec.js
+++ b/test/issue.spec.js
@@ -241,6 +241,7 @@ describe('Issue', function() {
       it('should update a label', (done) => {
          let label = {
             color: '789abc',
+            name: createdLabel
          };
 
          expect(createdLabel).to.be.a.string();

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -255,6 +255,17 @@ describe('Repository', function() {
          }));
       });
 
+      it('should get combined view of commit statuses for a SHA from a repo', function(done) {
+         remoteRepo.getCombinedStatus(v10SHA, assertSuccessful(done, function(err, combinedStatusesView) {
+            expect(combinedStatusesView.sha).to.equal(v10SHA);
+            expect(combinedStatusesView.state).to.equal('success');
+            expect(combinedStatusesView.statuses[0].context).to.equal('continuous-integration/travis-ci/push');
+            expect(combinedStatusesView.total_count).to.equal(1);
+
+            done();
+         }));
+      });
+
       it('should get a SHA from a repo', function(done) {
          remoteRepo.getSha('master', '.gitignore', assertSuccessful(done));
       });


### PR DESCRIPTION
The implemented of the combined status API call.

This is a re-implementation of #397 and #429 (as these are stale at this point) and closes #426.