### PR TITLE
RegExp Fix for _requestAllPages

### DIFF
--- a/lib/Requestable.js
+++ b/lib/Requestable.js
@@ -261,7 +261,7 @@ class Requestable {
                   options = {};
                }
                options.page = parseInt(
-                 nextUrl.match(/(page=[0-9]*)/g)
+                 nextUrl.match(/(&page=[0-9]*)/g)
                    .shift()
                    .split('=')
                    .pop()

--- a/lib/Requestable.js
+++ b/lib/Requestable.js
@@ -261,7 +261,7 @@ class Requestable {
                   options = {};
                }
                options.page = parseInt(
-                 nextUrl.match(/(&page=[0-9]*)/g)
+                 nextUrl.match(/([&\?]page=[0-9]*)/g)
                    .shift()
                    .split('=')
                    .pop()


### PR DESCRIPTION
Hi @j-rewerts 

Remember we remove ampersand in this PR
https://github.com/github-tools/github/pull/575/commits/86775a64496ae26bd8607492a0606c78ed1f0c7b#diff-5a59658a5ca4e1b25fde329807afc34fR264-R265

https://github.com/github-tools/github/blob/86775a64496ae26bd8607492a0606c78ed1f0c7b/lib/Requestable.js#L264-L264

Unfortunately regexp then mach other get parameter like &per_page  

```js
nextUrl =
"https://github.ldn.swissbank.com/api/v3/organizations/68/repos?direction=desc&type=all&sort=updated&per_page=100&page=2"
parseInt(nextUrl.match(/(page=[0-9]*)/g).shift().split('=').pop()); // 100

parseInt(nextUr.match(/([&\?]page=[0-9]*)/g).shift().split('=').pop()); // 2
```

@j-rewerts I suggest to add use this improved regexp that will match both cases: `?page=, &page=`