### PR TITLE
Add pagination to search endpoints

### DIFF
--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -91,11 +91,11 @@ class GitHub {
 
    /**
     * Create a new Search wrapper
-    * @param {string} query - the query to search for
+    * @param {Search.Params} searchParameters - the query and other search parameters
     * @return {Search}
     */
-   search(query) {
-      return new Search(query, this.__auth, this.__apiBase);
+   search(searchParameters) {
+      return new Search(searchParameters, this.__auth, this.__apiBase);
    }
 
    /**

--- a/lib/Requestable.js
+++ b/lib/Requestable.js
@@ -235,13 +235,30 @@ class Requestable {
     * @param {string} path - the path to request
     * @param {Object} options - the query parameters to include
     * @param {Requestable.callback} [cb] - the function to receive the data. The returned data will always be an array.
-    * @param {Object[]} results - the partial results. This argument is intended for internal use only.
     * @return {Promise} - a promise which will resolve when all pages have been fetched
     * @deprecated This will be folded into {@link Requestable#_request} in the 2.0 release.
     */
-   _requestAllPages(path, options, cb, results) {
-      results = results || [];
+   _requestAllPages(path, options, cb) {
+      let manualPagination = false;
+      if (typeof options.page !== 'undefined') {
+         manualPagination = true;
+      }
 
+      return this._requestAllPagesHelper(path, options, cb, [], manualPagination);
+   }
+
+   /**
+    * Perform the logic of fetching multiple pages
+    * @private
+    * @param {string} path - the path to request
+    * @param {Object} options - the query parameters to include
+    * @param {Requestable.callback} [cb] - the function to receive the data. The returned data will always be an array.
+    * @param {Object[]} results - the partial results. This argument is intended for internal use only.
+    * @param {boolean} manualPagination - the flag to decide if multiple pages should be fetched
+    * @return {Promise} - a promise which will resolve when all pages have been fetched
+    * @deprecated This will be folded into {@link Requestable#_request} in the 2.0 release.
+    */
+   _requestAllPagesHelper(path, options, cb, results, manualPagination) {
       return this._request('GET', path, options)
          .then((response) => {
             let thisGroup;
@@ -256,19 +273,19 @@ class Requestable {
             results.push(...thisGroup);
 
             const nextUrl = getNextPage(response.headers.link);
-            if(nextUrl) {
+            if(nextUrl && !manualPagination) {
                if (!options) {
                   options = {};
                }
                options.page = parseInt(
-                 nextUrl.match(/([&\?]page=[0-9]*)/g)
-                   .shift()
-                   .split('=')
-                   .pop()
+                  nextUrl.match(/([&\?]page=[0-9]*)/g)
+                     .shift()
+                     .split('=')
+                     .pop()
                );
                if (!(options && typeof options.page !== 'number')) {
                   log(`getting next page: ${nextUrl}`);
-                  return this._requestAllPages(nextUrl, options, cb, results);
+                  return this._requestAllPagesHelper(nextUrl, options, cb, results, false);
                }
             }
 

--- a/lib/Search.js
+++ b/lib/Search.js
@@ -32,6 +32,8 @@ class Search extends Requestable {
     * @param {string} sort - the sort field, one of `stars`, `forks`, or `updated`.
     *                      Default is [best match](https://developer.github.com/v3/search/#ranking-search-results)
     * @param {string} order - the ordering, either `asc` or `desc`
+    * @param {number} page - the page number to fetch, for manual pagination
+    * @param {number} per_page - the number of results to fetch per page, for manual pagination
     */
    /**
     * Perform a search on the GitHub API

--- a/test/search.spec.js
+++ b/test/search.spec.js
@@ -28,7 +28,22 @@ describe('Search', function() {
       return search.forRepositories(options)
          .then(function({data}) {
             expect(data).to.be.an.array();
-            expect(data.length).to.be.above(0);
+            expect(data.length).to.be.above(100);
+         });
+   });
+
+   it('should not paginate when provided an optional page parameter', function() {
+      let options = {page: 1};
+      let search = github.search({
+         q: 'tetris language:assembly',
+         sort: 'stars',
+         order: 'desc',
+      });
+
+      return search.forRepositories(options)
+         .then(function({data}) {
+            expect(data).to.be.an.array();
+            expect(data.length).to.equal(100);
          });
    });
 


### PR DESCRIPTION
Changes:

- Updated the jsdoc to correctly document the `Github.search` function.
- If a `page` option is passed into `_requestAllPages`, it will only fetch that single page, instead of attempting to fetch all of the pages.
- Removed the `results` parameter from `_requestAllPages`, since that is only meant to be used internally anyway. It's trivial to re-introduce, so let me know if this makes sense to do, since this could break some backwards compatibility if folks are using an unsupported argument.
- Added a test for pagination, and a new fixture for that test. Fixed a number of other fixtures that didn't seem to have the correct page number.