### PR TITLE
fix(repository): prevents lib from crashing when not providing option…

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -749,6 +749,7 @@ class Repository extends Requestable {
     * @return {Promise} - the promise for the http request
     */
    writeFile(branch, path, content, message, options, cb) {
+      options = options || {};
       if (typeof options === 'function') {
          cb = options;
          options = {};

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -385,6 +385,17 @@ describe('Repository', function() {
          }));
       });
 
+      it('should successfully write to repo when not providing optional options argument', function(done) {
+         remoteRepo.writeFile('master', fileName, initialText, initialMessage, undefined, assertSuccessful(done, function() {
+            wait()().then(() => remoteRepo.getContents('master', fileName, 'raw',
+               assertSuccessful(done, function(err, fileText) {
+                  expect(fileText).to.be(initialText);
+
+                  done();
+               })));
+         }));
+      });
+
       it('should rename files', function(done) {
          remoteRepo.writeFile('master', fileName, initialText, initialMessage, assertSuccessful(done, function() {
             wait()().then(() => remoteRepo.move('master', fileName, 'new_name', assertSuccessful(done, function() {


### PR DESCRIPTION
…al arguments

Ran into this issue today described in this old PR: https://github.com/github-tools/github/pull/456

This provides the same fix and adds a test case, though I can't run the tests since it asks me to email jaredrewerts@gmail.com to get access.