### PR TITLE
Organizations.listMembers() used _request()

### DIFF
--- a/lib/Organization.js
+++ b/lib/Organization.js
@@ -65,7 +65,7 @@ class Organization extends Requestable {
     * @return {Promise} - the promise for the http request
     */
    listMembers(options, cb) {
-      return this._request('GET', `/orgs/${this.__name}/members`, options, cb);
+      return this._requestAllPages(`/orgs/${this.__name}/members`, options, cb);
    }
 
    /**


### PR DESCRIPTION
Organizations.listMembers() used _request() instead of _requestAllPages(), unlike other similar methods.