### PR TITLE
chore: update axios due to CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dist/*"
   ],
   "dependencies": {
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "debug": "^2.2.0",
     "js-base64": "^2.1.9",
     "utf8": "^2.1.1"


### PR DESCRIPTION
There's a CVE for axios < 0.21.1.
See https://github.com/advisories/GHSA-4w2v-q235-vp99

Closes #633

---

Note - Haven't yet tested, but have emailed asking for a token.