### PR TITLE
Update Repository.js to works with png

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -784,9 +784,9 @@ class Repository extends Requestable {
       return this.getSha(branch, filePath)
          .then((response) => {
             commit.sha = response.data.sha;
-            return this._request('PUT', `/repos/${this.__fullname}/contents/${filePath}`, commit, cb);
+            return this._request('PUT', `/repos/${this.__fullname}/contents/${filePath}`, commit, cb, options.raw);
          }, () => {
-            return this._request('PUT', `/repos/${this.__fullname}/contents/${filePath}`, commit, cb);
+            return this._request('PUT', `/repos/${this.__fullname}/contents/${filePath}`, commit, cb, options.raw);
          });
    }
 


### PR DESCRIPTION
Using the raw parameter within the options of the writeFile method, this tool works with the sending of png images, it has not been tested with other files, but I think this solution will work for others as well.

```
  writePng(fileNamePng:string,base64Png:any,commitMsg:string=''){
    let initialMessage=commitMsg||'Commit de '+base64Png;
    let option = {encode:false,raw:true}
    const promise = this.bagRepo.writeFile('master', fileNamePng, base64Png, initialMessage, option);
    promise.then((valor:any) => {
      // console.log(valor);
    },this.initRepo);
    return promise;
  }
```