### PR TITLE
Add getStargazers() and getWatchers() methods to Repository

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -454,6 +454,26 @@ class Repository extends Requestable {
    }
 
    /**
+    * List the stargazers to the repository
+    * @see https://developer.github.com/v3/repos/#get-stargazers
+    * @param {Requestable.callback} cb - will receive the list of contributors
+    * @return {Promise} - the promise for the http request
+    */
+   getStargazers(cb) {
+      return this._request('GET', `/repos/${this.__fullname}/stargazers`, null, cb);
+   }
+
+   /**
+    * List the watchers to the repository
+    * @see https://developer.github.com/v3/repos/#get-watchers
+    * @param {Requestable.callback} cb - will receive the list of contributors
+    * @return {Promise} - the promise for the http request
+    */
+   getWatchers(cb) {
+      return this._request('GET', `/repos/${this.__fullname}/watchers`, null, cb);
+   }
+
+   /**
     * List the contributors to the repository
     * @see https://developer.github.com/v3/repos/#list-contributors
     * @param {Requestable.callback} cb - will receive the list of contributors


### PR DESCRIPTION
Hello dear developers. I added to the `Repository` class the `getStargazers` and `getWatchers` methods. I hope you can merge it. :nerd_face: